### PR TITLE
Allow spiderable + picker usage

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -1,4 +1,4 @@
 Picker = new PickerImp();
-WebApp.connectHandlers.use(function(req, res, next) {
+WebApp.rawConnectHandlers.use(function(req, res, next) {
   Picker._dispatch(req, res, next);
 });


### PR DESCRIPTION
At the moment if you use spiderable you can't use `_escaped_fragment_=` in the url, `_escaped_fragment_` works fine. Google will request the one with the `=` though, I think?. It might be better to allow it to work too. The issue only occurs if you use spiderable as well as this package.

This edit allows the router to give first preference to those with `Picker.route` so you can use spiderable for certain routes & use this for others without spiderable blocking routes used by `Picker` (since spiderable's middleware is higher on the stack)