### PR TITLE
Fixes broken testing dependencies and updates path-to-regexp

### DIFF
--- a/.npm/package/.gitignore
+++ b/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/package/README
+++ b/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,7 +1,12 @@
 {
   "dependencies": {
     "path-to-regexp": {
-      "version": "1.0.1"
+      "version": "1.2.1",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1"
+        }
+      }
     }
   }
 }

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "path-to-regexp": {
+      "version": "1.0.1"
+    }
+  }
+}

--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'path-to-regexp': '1.0.1'
+  'path-to-regexp': '1.2.1'
 });
 
 Package.onUse(function(api) {

--- a/package.js
+++ b/package.js
@@ -1,35 +1,34 @@
 Package.describe({
-  "summary": "Server Side Router for Meteor",
-  "version": "1.0.3",
-  "git": "https://github.com/meteorhacks/picker.git",
-  "name": "meteorhacks:picker"
+  name: 'meteorhacks:picker',
+  summary: 'Server Side Router for Meteor',
+  version: '1.0.3',
+  git: 'https://github.com/meteorhacks/picker.git'
 });
 
 Npm.depends({
-  "path-to-regexp": "1.0.1"
+  'path-to-regexp': '1.0.1'
 });
 
-Package.on_use(function(api) {
+Package.onUse(function(api) {
   configurePackage(api);
   api.export(['Picker']);
 });
 
-Package.on_test(function(api) {
+Package.onTest(function(api) {
   configurePackage(api);
-
-  api.use(['tinytest', 'http'], ['server']);
-  api.add_files([
+  api.use(['tinytest', 'http', 'random'], ['server']);
+  api.addFiles([
     'test/instance.js'
   ], ['server']);
 });
 
 function configurePackage(api) {
   if(api.versionsFrom) {
-    api.versionsFrom('METEOR@0.9.0');
+    api.versionsFrom('METEOR@1.2');
   }
-  
+
   api.use(['webapp', 'underscore'], ['server']);
-  api.add_files([
+  api.addFiles([
     'lib/implementation.js',
     'lib/instance.js',
   ], ['server']);


### PR DESCRIPTION
Tests were not working due to missing `random` dependency. `path-to-regexp` was updated to v1.2.1 for consistency with FlowRouter and Page.js.