### PR TITLE
Beginning of an attempt to properly decode url parameters

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -63,7 +63,7 @@ PickerImp.prototype._dispatch = function(req, res, bypass) {
       }
     } else {
       processNextSubRouter();
-    } 
+    }
   }
 
   function processNextSubRouter () {
@@ -80,7 +80,7 @@ PickerImp.prototype._buildParams = function(keys, m) {
   var params = {};
   for(var lc=1; lc<m.length; lc++) {
     var key = keys[lc-1].name;
-    var value = m[lc];
+    var value = decodeURIComponent(decodeURIComponent(m[lc]));
     params[key] = value;
   }
 
@@ -95,7 +95,7 @@ PickerImp.prototype._processRoute = function(callback, params, req, res, next) {
   }
 
   function doCall () {
-    callback.call(null, params, req, res, next); 
+    callback.call(null, params, req, res, next);
   }
 };
 


### PR DESCRIPTION
While researching the cause of this bug https://github.com/kadirahq/flow-router/issues/379 I discovered that with SSR, parameters are decoded on client side but not the server, which resulted in error. It turns out that Picker was parsing the route parameters differently from Page.js. This is an initial attempt to fix that. This is not yet ready to be merged.
