### PR TITLE
Fix issue when several routes match current path

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -57,7 +57,7 @@ PickerImp.prototype._dispatch = function(req, res, bypass) {
       if(m) {
         var params = self._buildParams(route.keys, m);
         params.query = urlParse(req.url, true).query;
-        self._processRoute(route.callback, params, req, res, bypass);
+        self._processRoute(route.callback, params, req, res, processNextRoute);
       } else {
         processNextRoute();
       }


### PR DESCRIPTION
Currently, doing:

``` javascript
Picker.route('somePath', (params, req, res, next) => {
  if (req.method == 'POST') {
     ...
  } else { next(); }
});
Picker.route('somePath', (params, req, res, next) => {
  if (req.method == 'GET') {
     ...
  } else { next(); }
});
```

will not reach the GET route if the request is `GET somePath`.
For any other example where several route definitions match the current path, calling next will not go to the next definition.

If you accept the PR, it's be good to update picker's version and the dependency in flow-router-ssr at https://github.com/kadirahq/flow-router/blob/ssr/package.js#L61
