### PR TITLE
Fix subrouters middelware dependencies

### DIFF
--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -49,6 +49,8 @@ PickerImp.prototype._dispatch = function(req, res, bypass) {
     var middleware = self.middlewares[currentMiddleware++];
     if(middleware) {
       self._processMiddleware(middleware, req, res, () => { processNextMiddleware(onDone); });
+    } else {
+      onDone();
     }
   }
 

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -11,6 +11,9 @@ PickerImp = function(filterFunction) {
 
 PickerImp.prototype.middleware = function(callback) {
   this.middlewares.push(callback);
+  for(const subRouter of this.subRouters) {
+    subRouter.middleware(callback);
+  }
 };
 
 PickerImp.prototype.route = function(path, callback) {
@@ -23,6 +26,9 @@ PickerImp.prototype.route = function(path, callback) {
 PickerImp.prototype.filter = function(callback) {
   var subRouter = new PickerImp(callback);
   this.subRouters.push(subRouter);
+  for(const middleware of this.middlewares) {
+    subRouter.middleware(middleware);
+  }
   return subRouter;
 };
 
@@ -39,13 +45,10 @@ PickerImp.prototype._dispatch = function(req, res, bypass) {
     }
   }
 
-  processNextMiddleware();
   function processNextMiddleware () {
     var middleware = self.middlewares[currentMiddleware++];
     if(middleware) {
       self._processMiddleware(middleware, req, res, processNextMiddleware);
-    } else {
-      processNextRoute();
     }
   }
 
@@ -54,7 +57,8 @@ PickerImp.prototype._dispatch = function(req, res, bypass) {
     if(route) {
       var uri = req.url.replace(/\?.*/, '');
       var m = uri.match(route);
-      if(m) {
+      if (m) {
+        processNextMiddleware();
         var params = self._buildParams(route.keys, m);
         params.query = urlParse(req.url, true).query;
         self._processRoute(route.callback, params, req, res, bypass);
@@ -65,6 +69,7 @@ PickerImp.prototype._dispatch = function(req, res, bypass) {
       processNextSubRouter();
     } 
   }
+  processNextRoute();
 
   function processNextSubRouter () {
     var subRouter = self.subRouters[currentSubRouter++];

--- a/lib/implementation.js
+++ b/lib/implementation.js
@@ -45,10 +45,10 @@ PickerImp.prototype._dispatch = function(req, res, bypass) {
     }
   }
 
-  function processNextMiddleware () {
+  function processNextMiddleware (onDone) {
     var middleware = self.middlewares[currentMiddleware++];
     if(middleware) {
-      self._processMiddleware(middleware, req, res, processNextMiddleware);
+      self._processMiddleware(middleware, req, res, () => { processNextMiddleware(onDone); });
     }
   }
 
@@ -58,10 +58,11 @@ PickerImp.prototype._dispatch = function(req, res, bypass) {
       var uri = req.url.replace(/\?.*/, '');
       var m = uri.match(route);
       if (m) {
-        processNextMiddleware();
-        var params = self._buildParams(route.keys, m);
-        params.query = urlParse(req.url, true).query;
-        self._processRoute(route.callback, params, req, res, bypass);
+        processNextMiddleware(() => {
+          var params = self._buildParams(route.keys, m);
+          params.query = urlParse(req.url, true).query;
+          self._processRoute(route.callback, params, req, res, bypass);
+        });
       } else {
         processNextRoute();
       }

--- a/package.js
+++ b/package.js
@@ -27,7 +27,7 @@ function configurePackage(api) {
     api.versionsFrom('METEOR@1.2');
   }
 
-  api.use(['webapp', 'underscore'], ['server']);
+  api.use(['webapp', 'underscore', 'ecmascript'], ['server']);
   api.addFiles([
     'lib/implementation.js',
     'lib/instance.js',

--- a/test/instance.js
+++ b/test/instance.js
@@ -87,6 +87,40 @@ Tinytest.add('middlewares - with filtered routes', function(test) {
   test.equal(res.content, "ok");
 });
 
+Tinytest.add('middlewares - with several filtered routes', function(test) {
+  var path1 = "/" + Random.id() + "/coola";
+  var path2 = "/" + Random.id() + "/coola";
+
+  var routes1 = Picker.filter();
+  var routes2 = Picker.filter();
+
+  const increaseResultBy = (i) => (req, res, next) => {
+    setTimeout(function() {
+      req.result = req.result || 0;
+      req.result += i;
+      next();
+    }, 100);
+  };
+
+  routes1.middleware(increaseResultBy(1));
+  routes2.middleware(increaseResultBy(2));
+
+  Picker.middleware(increaseResultBy(10));
+
+  routes1.route(path1, function(params, req, res) {
+    res.end(req.result+'');
+  });
+  routes2.route(path2, function(params, req, res) {
+    res.end(req.result+'');
+  });
+
+  var res = HTTP.get(getPath(path1));
+  test.equal(res.content, "11");
+
+  var res = HTTP.get(getPath(path2));
+  test.equal(res.content, "12");
+});
+
 var urlResolve = Npm.require('url').resolve;
 function getPath(path) {
   return urlResolve(process.env.ROOT_URL, path);


### PR DESCRIPTION
Only run middlewares after a route is hit, and define all the middlewares at the router level so that each subrouter is independant.
